### PR TITLE
chore(DELENG-438): update CODEOWNERS @qa-team → @quality-engineering

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Default code owner for this repository
-* @pantheon-systems/qa-team @siddharth-pantheon @vivek-shamanna @YashawanthkumarH @ander-murane @OmTrivedi01 @ajitsolanki27
+* @pantheon-systems/quality-engineering @siddharth-pantheon @vivek-shamanna @YashawanthkumarH @ander-murane @OmTrivedi01 @ajitsolanki27
 * @pantheon-systems/developer-experience 


### PR DESCRIPTION
## Summary
- Replaces `@pantheon-systems/qa-team` with `@pantheon-systems/quality-engineering` in CODEOWNERS

## Why
`qa-team` is an alias slug - `quality-engineering` is the canonical team name managed in github-terraform.

## Test Plan
- [x] CODEOWNERS diff reviewed

Jira: https://getpantheon.atlassian.net/browse/DELENG-438